### PR TITLE
Issue #10 - better handling of double-quoted command line arguments

### DIFF
--- a/src/templates/template-install.sh
+++ b/src/templates/template-install.sh
@@ -40,7 +40,7 @@ function createDesktopShortcut {
   echo "Categories=${CATEGORY}" >> $SHORTCUT_FILE
   echo "Name=${2}" >> $SHORTCUT_FILE
   echo "Comment=" >> $SHORTCUT_FILE
-  echo "Exec=${1}/bin/${2} %F" >> $SHORTCUT_FILE
+  echo "Exec=${1}/bin/${2} \"%F\"" >> $SHORTCUT_FILE
   echo "Icon=${1}/logo.png" >> $SHORTCUT_FILE
   echo "Path=${3}" >> $SHORTCUT_FILE
   echo "Terminal=false" >> $SHORTCUT_FILE

--- a/src/templates/template-launcher.sh
+++ b/src/templates/template-launcher.sh
@@ -53,7 +53,7 @@ while true; do
       -DINSTALL_DIR=${INSTALL_DIR} \
       -DSETTINGS_DIR=${SETTINGS_DIR} \
       -DEXTENSIONS_DIR=${EXTENSIONS_DIR} \
-      -jar ${INSTALL_DIR}/${APPLICATION}.jar $*
+      -jar ${INSTALL_DIR}/${APPLICATION}.jar "$@"
     exit_code=$?
 
     if [ $exit_code -eq $APPLICATION_RESTART ]; then


### PR DESCRIPTION
Addresses an issue where applications were not given command-line arguments with spaces in them properly. For example, an argument of `"hello there"` was being interpreted as two separate command-line arguments: `"hello` and `there"`. This isn't acceptable, as many applications have to be able to open files that have spaces in the name and/or path.

This PR has two changes:
- when creating the application shortcut, be sure to use `"%F"` instead of `%F` for handling arguments. The double quotes are important!
- In the application launcher, don't use `$*` to forward arguments to the java application, because that will fail. Instead, use `"$@"` to properly handle double-quoted arguments.