### PR TITLE
Don't double-quote %F

### DIFF
--- a/src/templates/template-install.sh
+++ b/src/templates/template-install.sh
@@ -40,7 +40,7 @@ function createDesktopShortcut {
   echo "Categories=${CATEGORY}" >> $SHORTCUT_FILE
   echo "Name=${2}" >> $SHORTCUT_FILE
   echo "Comment=" >> $SHORTCUT_FILE
-  echo "Exec=${1}/bin/${2} \"%F\"" >> $SHORTCUT_FILE
+  echo "Exec=${1}/bin/${2} %F" >> $SHORTCUT_FILE
   echo "Icon=${1}/logo.png" >> $SHORTCUT_FILE
   echo "Path=${3}" >> $SHORTCUT_FILE
   echo "Terminal=false" >> $SHORTCUT_FILE


### PR DESCRIPTION
The `Exec` entry in a .desktop file on linux should not double-quote %F:

Wrong:

```
Exec=/path/to/app "%F"
```

Right:

```
Exec=/path/to/app %F
```

The problem is that when selecting multiple files in a file browser, right-clicking them, and selecting "Open in (Application)", the double-quotes around %F were causing all arguments to be passed as one big long command line argument, with each file wrapped in single quotes, like this:

```
arg[0]: 'file1.txt' 'file2.txt' 'file3.txt'
```

Removing the double quotes around %F corrects this, so the application will instead receive:

```
arg[0]: file1.txt
arg[1]: file2.txt
arg[2]: file3.txt
```

This problem was confusing because the application launcher script was originally using `$*` to pass arguments to the Java application, instead of `"$@"` - that made this issue difficult to debug.

The correct combination seems to be to use `%F` (no double quotes) in the application desktop file, and `"$@"` (with double quotes) in the application's launcher bash script. Only this combination results in arguments being correctly and consistently passed to the Java application.