### PR TITLE
Issue #13 and #14 - fix install script bugs

### DIFF
--- a/src/make-installer
+++ b/src/make-installer
@@ -133,7 +133,7 @@ chmod 755 ${WORKINGDIR}/bin/${APPLICATION}
 chmod 755 ${WORKINGDIR}/bin/uninstall.sh
 
 # Optionally throw in an INSTALL.txt with project information if there isn't one already:
-if [ "${PROJECT_URL}" != "" -a ! -f "${WORKINGDIR}/INSTALL.txt" ]; then
+if [ -n "${PROJECT_URL}" ] && [ ! -f "${WORKINGDIR}/INSTALL.txt" ]; then
   echo "This is the installer tarball for ${APPLICATION}-${VERSION}" > ${WORKINGDIR}/INSTALL.txt
   echo "Project URL: ${PROJECT_URL}" >> ${WORKINGDIR}/INSTALL.txt
   echo "" >> ${WORKINGDIR}/INSTALL.txt

--- a/src/make-installer
+++ b/src/make-installer
@@ -133,7 +133,7 @@ chmod 755 ${WORKINGDIR}/bin/${APPLICATION}
 chmod 755 ${WORKINGDIR}/bin/uninstall.sh
 
 # Optionally throw in an INSTALL.txt with project information if there isn't one already:
-if [ ${PROJECT_URL} != "" -a ! -f ${WORKINGDIR}/INSTALL.txt ]; then
+if [ "${PROJECT_URL}" != "" -a ! -f "${WORKINGDIR}/INSTALL.txt" ]; then
   echo "This is the installer tarball for ${APPLICATION}-${VERSION}" > ${WORKINGDIR}/INSTALL.txt
   echo "Project URL: ${PROJECT_URL}" >> ${WORKINGDIR}/INSTALL.txt
   echo "" >> ${WORKINGDIR}/INSTALL.txt

--- a/src/templates/template-install.sh
+++ b/src/templates/template-install.sh
@@ -119,7 +119,7 @@ if [ -d $INSTALL_DIR ]; then
     fi
   fi
 else
-  mkdir -p $INSTALL_DIR
+  mkdir -p "$INSTALL_DIR"
 fi
 
 

--- a/src/templates/template-install.sh
+++ b/src/templates/template-install.sh
@@ -118,6 +118,8 @@ if [ -d $INSTALL_DIR ]; then
       exit 1
     fi
   fi
+else
+  mkdir -p $INSTALL_DIR
 fi
 
 


### PR DESCRIPTION
This PR is to address two critical bugs in the install script generators:

- #13 - the generated installer script would not properly copy subdirectories to the target location if the target location did not already exist. 
- #14 - if the PROJECT_URL installer property had no value set, the script would fail with an error caused by an unquoted variable usage in an "if" statement.

These bugs are both serious, but #13 in particular is critical, as it prevents ALL new installs from working (only upgrades are currently working, because the install directory already exists in that case).