### PR TITLE
Issue #16 - add short-term fix for unnamed module issue in java 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ OUTPUT_DIR=target
 # Extra memory settings like Xmx and Xms can optionally be specified here:
 JAVAMEM=
 
+# Any extra arguments to be passed to the java command:
+EXTRA_JAVA_ARGS=
+
 # The executable application jar file to be bundled into the tarball:
 JAR="target/myapplication-${VERSION}.jar"
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ PROJECT_URL="https://project.example/MyApplication"
 OUTPUT_DIR=target
 
 # Extra memory settings like Xmx and Xms can optionally be specified here:
-JAVAMEM=
+JAVA_MEM=
 
 # Any extra arguments to be passed to the java command:
 EXTRA_JAVA_ARGS=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ OUTPUT_DIR=target
 JAVA_MEM=
 
 # Any extra arguments to be passed to the java command:
+# For example, in Java 24+, to suppress unnamed-module warnings on startup: 
+# EXTRA_JAVA_ARGS="--enable-native-access=ALL-UNNAMED"
 EXTRA_JAVA_ARGS=
 
 # The executable application jar file to be bundled into the tarball:

--- a/src/make-installer
+++ b/src/make-installer
@@ -27,7 +27,7 @@
 #  VERSION -> The major.minor version of your app.
 #            By convention we don't use major.minor.patch here.
 #  PROJECT_URL -> an optional URL for your project home.
-#  JAVAMEM -> Any extra java memory options you want the launcher
+#  JAVA_MEM -> Any extra java memory options you want the launcher
 #            to use when starting your application.
 #            Example: "-Xms1g -Xmx2g"
 #            An empty string is also fine here.
@@ -126,17 +126,24 @@ for file in ${TO_COPY} ; do
 done
 mkdir -p ${WORKINGDIR}/bin
 
+# Make our variables safe for sed:
+APPLICATION_ESCAPED=$(printf '%s\n' "${APPLICATION}" | sed 's/[&/\\#]/\\&/g')
+VERSION_ESCAPED=$(printf '%s\n' "${VERSION}" | sed 's/[&/\\#]/\\&/g')
+CATEGORY_ESCAPED=$(printf '%s\n' "${CATEGORY}" | sed 's/[&/\\#]/\\&/g')
+JAVA_MEM_ESCAPED=$(printf '%s\n' "${JAVA_MEM}" | sed 's/[&/\\#]/\\&/g')
+EXTRA_JAVA_ARGS_ESCAPED=$(printf '%s\n' "${EXTRA_JAVA_ARGS}" | sed 's/[&/\\#]/\\&/g')
+
 # Generate our launcher script and install/uninstall scripts:
 cat ${TEMPLATE_DIR}/template-install.sh \
-    | sed s#ApplicationGoesHere#${APPLICATION}#g \
-    | sed s#VersionGoesHere#${VERSION}#g \
-    | sed s#CategoryGoesHere#${CATEGORY}#g > ${WORKINGDIR}/install.sh
+    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g \
+    | sed s/VersionGoesHere/${VERSION_ESCAPED}/g \
+    | sed s/CategoryGoesHere/${CATEGORY_ESCAPED}/g > ${WORKINGDIR}/install.sh
 cat ${TEMPLATE_DIR}/template-launcher.sh \
-    | sed s#ApplicationGoesHere#${APPLICATION}#g \
-    | sed s#JavaMemGoesHere#${JAVA_MEM}#g \
-    | sed s#ExtraJavaArgsGoesHere#${EXTRA_JAVA_ARGS}#g > ${WORKINGDIR}/bin/${APPLICATION}
+    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g \
+    | sed s/JavaMemGoesHere/${JAVA_MEM_ESCAPED}/g \
+    | sed s/ExtraJavaArgsGoesHere/${EXTRA_JAVA_ARGS_ESCAPED}/g > ${WORKINGDIR}/bin/${APPLICATION}
 cat ${TEMPLATE_DIR}/template-uninstall.sh \
-    | sed s#ApplicationGoesHere#${APPLICATION}#g > ${WORKINGDIR}/bin/uninstall.sh
+    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g > ${WORKINGDIR}/bin/uninstall.sh
 chmod 755 ${WORKINGDIR}/install.sh
 chmod 755 ${WORKINGDIR}/bin/${APPLICATION}
 chmod 755 ${WORKINGDIR}/bin/uninstall.sh

--- a/src/make-installer
+++ b/src/make-installer
@@ -135,18 +135,18 @@ EXTRA_JAVA_ARGS_ESCAPED=$(printf '%s\n' "${EXTRA_JAVA_ARGS}" | sed 's/[&/\\#]/\\
 
 # Generate our launcher script and install/uninstall scripts:
 cat ${TEMPLATE_DIR}/template-install.sh \
-    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g \
-    | sed s/VersionGoesHere/${VERSION_ESCAPED}/g \
-    | sed s/CategoryGoesHere/${CATEGORY_ESCAPED}/g > ${WORKINGDIR}/install.sh
+    | sed "s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g" \
+    | sed "s/VersionGoesHere/${VERSION_ESCAPED}/g" \
+    | sed "s/CategoryGoesHere/${CATEGORY_ESCAPED}/g" > ${WORKINGDIR}/install.sh
 cat ${TEMPLATE_DIR}/template-launcher.sh \
-    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g \
-    | sed s/JavaMemGoesHere/${JAVA_MEM_ESCAPED}/g \
-    | sed s/ExtraJavaArgsGoesHere/${EXTRA_JAVA_ARGS_ESCAPED}/g > ${WORKINGDIR}/bin/${APPLICATION}
+    | sed "s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g" \
+    | sed "s/JavaMemGoesHere/${JAVA_MEM_ESCAPED}/g" \
+    | sed "s/ExtraJavaArgsGoesHere/${EXTRA_JAVA_ARGS_ESCAPED}/g" > ${WORKINGDIR}/bin/${APPLICATION}
 cat ${TEMPLATE_DIR}/template-uninstall.sh \
-    | sed s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g > ${WORKINGDIR}/bin/uninstall.sh
-chmod 755 ${WORKINGDIR}/install.sh
-chmod 755 ${WORKINGDIR}/bin/${APPLICATION}
-chmod 755 ${WORKINGDIR}/bin/uninstall.sh
+    | sed "s/ApplicationGoesHere/${APPLICATION_ESCAPED}/g" > ${WORKINGDIR}/bin/uninstall.sh
+chmod 755 "${WORKINGDIR}/install.sh"
+chmod 755 "${WORKINGDIR}/bin/${APPLICATION}"
+chmod 755 "${WORKINGDIR}/bin/uninstall.sh"
 
 # Optionally throw in an INSTALL.txt with project information if there isn't one already:
 if [ -n "${PROJECT_URL}" ] && [ ! -f "${WORKINGDIR}/INSTALL.txt" ]; then

--- a/src/make-installer
+++ b/src/make-installer
@@ -31,6 +31,8 @@
 #            to use when starting your application.
 #            Example: "-Xms1g -Xmx2g"
 #            An empty string is also fine here.
+#  EXTRA_JAVA_ARGS -> Any extra java arguments you want the launcher
+#                  to pass to java when starting your application.
 #  JAR -> The location of your executable jar.
 #         This path should be relative to the current dir.
 #  TO_COPY -> An optional space-separated list of extra files
@@ -125,9 +127,16 @@ done
 mkdir -p ${WORKINGDIR}/bin
 
 # Generate our launcher script and install/uninstall scripts:
-cat ${TEMPLATE_DIR}/template-install.sh | sed s/ApplicationGoesHere/${APPLICATION}/g | sed s/VersionGoesHere/${VERSION}/g | sed s/CategoryGoesHere/${CATEGORY}/g > ${WORKINGDIR}/install.sh
-cat ${TEMPLATE_DIR}/template-launcher.sh | sed s/ApplicationGoesHere/${APPLICATION}/g | sed s/JavaMemGoesHere/${JAVA_MEM}/g > ${WORKINGDIR}/bin/${APPLICATION}
-cat ${TEMPLATE_DIR}/template-uninstall.sh | sed s/ApplicationGoesHere/${APPLICATION}/g > ${WORKINGDIR}/bin/uninstall.sh
+cat ${TEMPLATE_DIR}/template-install.sh \
+    | sed s#ApplicationGoesHere#${APPLICATION}#g \
+    | sed s#VersionGoesHere#${VERSION}#g \
+    | sed s#CategoryGoesHere#${CATEGORY}#g > ${WORKINGDIR}/install.sh
+cat ${TEMPLATE_DIR}/template-launcher.sh \
+    | sed s#ApplicationGoesHere#${APPLICATION}#g \
+    | sed s#JavaMemGoesHere#${JAVA_MEM}#g \
+    | sed s#ExtraJavaArgsGoesHere#${EXTRA_JAVA_ARGS}#g > ${WORKINGDIR}/bin/${APPLICATION}
+cat ${TEMPLATE_DIR}/template-uninstall.sh \
+    | sed s#ApplicationGoesHere#${APPLICATION}#g > ${WORKINGDIR}/bin/uninstall.sh
 chmod 755 ${WORKINGDIR}/install.sh
 chmod 755 ${WORKINGDIR}/bin/${APPLICATION}
 chmod 755 ${WORKINGDIR}/bin/uninstall.sh

--- a/src/templates/template-launcher.sh
+++ b/src/templates/template-launcher.sh
@@ -17,6 +17,11 @@ EXTENSIONS_DIR="${SETTINGS_DIR}/extensions"
 # if your application has specific requirements:
 JAVA_MEM="JavaMemGoesHere"
 
+# You can optionally provide additional Java arguments
+# to be passed to java on startup:
+# (example: --enable-native-access=ALL-UNNAMED)
+EXTRA_JAVA_ARGS="ExtraJavaArgsGoesHere"
+
 # We need to find the directory where ApplicationGoesHere is installed,
 # and the name of the script that was invoked.
 # Note readlink -f is used to disambiguate things in case we were
@@ -49,8 +54,7 @@ fi
 
 while true; do
     # Invoke ApplicationGoesHere with install dir, settings dir, and extensions dir:
-    $JAVA ${JAVA_MEM} \
-      --enable-native-access=ALL-UNNAMED \
+    $JAVA ${JAVA_MEM} ${EXTRA_JAVA_ARGS} \
       -DINSTALL_DIR=${INSTALL_DIR} \
       -DSETTINGS_DIR=${SETTINGS_DIR} \
       -DEXTENSIONS_DIR=${EXTENSIONS_DIR} \

--- a/src/templates/template-launcher.sh
+++ b/src/templates/template-launcher.sh
@@ -50,6 +50,7 @@ fi
 while true; do
     # Invoke ApplicationGoesHere with install dir, settings dir, and extensions dir:
     $JAVA ${JAVA_MEM} \
+      --enable-native-access=ALL-UNNAMED \
       -DINSTALL_DIR=${INSTALL_DIR} \
       -DSETTINGS_DIR=${SETTINGS_DIR} \
       -DEXTENSIONS_DIR=${EXTENSIONS_DIR} \


### PR DESCRIPTION
This PR introduces a short-term fix for the issue described in issue #16 - Java 25 has a problem with unnamed modules. This fix suppresses the warning emitted on startup. Long-term fix unknown, but this will do for now.

Also made our variable substitution safer by using a delimiter other than `/` with the `sed` command. This will better handle cases where the caller supplies a value with a slash in it.

Also standardize on `JAVA_MEM` instead of `JAVAMEM` since the script wasn't handling `JAVAMEM` anyway. The docs were wrong.